### PR TITLE
[change #8] 名前空間を Asciimage.Core に変更

### DIFF
--- a/Asciimage/Core/AsciiMat.cs
+++ b/Asciimage/Core/AsciiMat.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Asciimage
+namespace Asciimage.Core
 {
     public class AsciiMat
     {

--- a/Asciimage/Core/Asciimage.cs
+++ b/Asciimage/Core/Asciimage.cs
@@ -2,7 +2,7 @@
 using SkiaSharp;
 using System.Diagnostics;
 
-namespace Asciimage
+namespace Asciimage.Core
 {
     /// <summary>
     /// Provides methods for generating ASCII art from images.
@@ -39,7 +39,7 @@ namespace Asciimage
 
             // Calculate the number of segments
             int horizontalSegmentCount, verticalSegmentCount;
-            if ((config.Width == 0 && config.Height == 0) || config.Width < 0 || config.Height < 0)
+            if (config.Width == 0 && config.Height == 0 || config.Width < 0 || config.Height < 0)
             {
                 throw new ArgumentException("Invalid config.");
             }
@@ -101,7 +101,7 @@ namespace Asciimage
             int height = image.Height;
             SKColor[] pixels = new SKColor[width * height];
             image.Pixels.CopyTo(pixels, 0);
-            
+
             Parallel.For(0, height, y =>
             {
                 int offset = y * width;
@@ -207,7 +207,7 @@ namespace Asciimage
                     }
                 }
 
-                diff /= (seg.Vertical * seg.Horizontal);
+                diff /= seg.Vertical * seg.Horizontal;
 
                 if (diff < minDiff)
                 {

--- a/Asciimage/Core/AsciimageConfig.cs
+++ b/Asciimage/Core/AsciimageConfig.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Asciimage
+namespace Asciimage.Core
 {
     /// <summary>
     /// Config that specifies width, height, characters, color mode.

--- a/Asciimage/Core/ColorMode.cs
+++ b/Asciimage/Core/ColorMode.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Asciimage
+namespace Asciimage.Core
 {
     /// <summary>
     /// Color mode of the image.

--- a/Asciimage/Core/ConsoleColorExtension.cs
+++ b/Asciimage/Core/ConsoleColorExtension.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Asciimage
+namespace Asciimage.Core
 {
     public static class ConsoleColorExtension
     {

--- a/AsciimageTester/Test2.cs
+++ b/AsciimageTester/Test2.cs
@@ -1,5 +1,5 @@
-using Asciimage;
 using Asciimage.Brushes;
+using Asciimage.Core;
 using SkiaSharp;
 using System.Diagnostics;
 
@@ -31,7 +31,7 @@ public class Test2
 
         Debug.WriteLine($"{DateTimeOffset.Now:HH:mm:ss.fff} Start Generating");
 
-        AsciiMat mat = Asciimage.Asciimage.Generate(bitmap, brush, segs[0], new AsciimageConfig(height: 20, colorMode: ColorMode.Binary));
+        AsciiMat mat = Asciimage.Core.Asciimage.Generate(bitmap, brush, segs[0], new AsciimageConfig(height: 20, colorMode: ColorMode.Binary));
         
         Debug.WriteLine($"{DateTimeOffset.Now:HH:mm:ss.fff} End");
 


### PR DESCRIPTION
This pull request includes several changes to the `Asciimage` project, primarily focused on renaming files and updating namespaces to improve organization and maintainability. Additionally, there are minor code adjustments for better readability and functionality.

Namespace updates and file renaming:

* `Asciimage/AsciiMat.cs` was renamed to `Asciimage/Core/AsciiMat.cs`, and the namespace was updated to `Asciimage.Core`.
* `Asciimage/Asciimage.cs` was renamed to `Asciimage/Core/Asciimage.cs`, and the namespace was updated to `Asciimage.Core`.
* `Asciimage/AsciimageConfig.cs` was renamed to `Asciimage/Core/AsciimageConfig.cs`, and the namespace was updated to `Asciimage.Core`.
* `Asciimage/ColorMode.cs` was renamed to `Asciimage/Core/ColorMode.cs`, and the namespace was updated to `Asciimage.Core`.
* `Asciimage/ConsoleColorExtension.cs` was renamed to `Asciimage/Core/ConsoleColorExtension.cs`, and the namespace was updated to `Asciimage.Core`.

Code improvements:

* Simplified the condition in the `Generate` method of `Asciimage/Core/Asciimage.cs` by removing unnecessary parentheses.
* Removed redundant parentheses in the `GetSimilarCharacter` method of `Asciimage/Core/Asciimage.cs`.

Test file updates:

* Updated the namespace imports in `AsciimageTester/Test2.cs` to reflect the new `Asciimage.Core` namespace. [[1]](diffhunk://#diff-a09ef8c5d461239c407978db708ed0cf8b8c8cefbfc1025c383eea505591a86eL1-R2) [[2]](diffhunk://#diff-a09ef8c5d461239c407978db708ed0cf8b8c8cefbfc1025c383eea505591a86eL34-R34)