### PR TITLE
Quit using Pow() method

### DIFF
--- a/Asciimage/Core/Asciimage.cs
+++ b/Asciimage/Core/Asciimage.cs
@@ -203,7 +203,8 @@ namespace Asciimage.Core
                 {
                     for (int x = 0; x < seg.Horizontal; x++)
                     {
-                        diff += Math.Pow(area[y, x] - depthMap[y, x], 2);
+                        double d = area[y, x] - depthMap[y, x];
+                        diff += d == 0 ? 0 : d * d;
                     }
                 }
 


### PR DESCRIPTION
This pull request includes a small change to the `Asciimage/Core/Asciimage.cs` file. The change optimizes the calculation of the `diff` variable by avoiding the use of `Math.Pow` and instead using a conditional expression to square the difference directly.

* [`Asciimage/Core/Asciimage.cs`](diffhunk://#diff-4fab0e4b1339f6c41311a2dffbc7edc38ac864116b9f1aa60cfcb15552e30682L206-R207): Optimized the `diff` calculation in the `GetSimilarCharacter` method by replacing `Math.Pow` with a conditional expression to square the difference directly.