### PR TITLE
Asciimage/feature/#11 redesign brush structure

### DIFF
--- a/Asciimage/Brushes/BaseGridSegmentFontBrush.cs
+++ b/Asciimage/Brushes/BaseGridSegmentFontBrush.cs
@@ -1,0 +1,90 @@
+﻿using SkiaSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace Asciimage.Brushes
+{
+    public abstract class BaseGridSegmentedFontBrush(SKFont font, Dictionary<SegmentCount, CharacterAreaMap> characterAreas, SKSize? characterRatio = null) : IFontBrush
+    {
+        public SKFontInfo FontInfo { get; init; } = new SKFontInfo(font);
+        public Dictionary<SegmentCount, CharacterAreaMap> CharacterAreas { get; init; } = characterAreas;
+        public SKSize CharacterRatio { get; init; } = characterRatio ?? new(font.MeasureText("A"), font.Metrics.Descent - font.Metrics.Ascent);
+
+        public BaseGridSegmentedFontBrush(string fontFamily, Dictionary<SegmentCount, CharacterAreaMap> characterAreas, SKSize? characterRatio = null) :
+            this(SKTypeface.FromFamilyName(fontFamily), characterAreas, characterRatio)
+        { }
+        public BaseGridSegmentedFontBrush(SKTypeface fontFace, Dictionary<SegmentCount, CharacterAreaMap> characterAreas, SKSize? characterRatio = null) :
+            this(new SKFont(fontFace), characterAreas, characterRatio)
+        { }
+
+        protected abstract string GetSegmentCharacter(SKBitmap bitmap, SKRectI rect, SegmentCount seg);
+        
+        protected void ConvertToGridSegmentedSize(SKBitmap bitmap, int width, int height, out int gridSegmentWidth, out int gridSegmentHeight)
+        {
+            // Calculate the number of segments
+            int gsw, gsh;
+            if (width == -1 && height == -1 || width == 0 || height == 0)
+            {
+                throw new ArgumentException("Invalid config.");
+            }
+            else if (height == -1)
+            {
+                double segmentWidth = (double)bitmap.Width / width;
+                double segmentHeight = segmentWidth * CharacterRatio.Height / CharacterRatio.Width;
+                gsh = (int)Math.Round(bitmap.Height / segmentHeight);
+                gsw = width;
+            }
+            else if (width == -1)
+            {
+                double segmentHeight = (double)bitmap.Height / height;
+                double segmentWidth = segmentHeight * CharacterRatio.Width / CharacterRatio.Height;
+                gsw = (int)Math.Round(bitmap.Width / segmentWidth);
+                gsh = height;
+            }
+            else
+            {
+                gsw = width;
+                gsh = height;
+            }
+
+            gridSegmentWidth = gsw;
+            gridSegmentHeight = gsh;
+        }
+
+        public string[,] GetStringMap(SKBitmap bitmap, int stringWidth, int stringHeight, SegmentCount seg)
+        {
+            ConvertToGridSegmentedSize(bitmap, stringWidth, stringHeight, out int gridSegmentWidth, out int gridSegmentHeight);
+
+            // Divide the image by config.Width and config.Height, and repeat the following process for each region
+            double cellWidth = (double)bitmap.Width / gridSegmentWidth;
+            double cellHeight = (double)bitmap.Height / gridSegmentHeight;
+
+            string[,] asciiArt = new string[gridSegmentHeight, gridSegmentWidth];
+
+            // Iterate over each region
+            for (int y = 0; y < gridSegmentHeight; y++)
+            {
+                int yMin = (int)Math.Floor(cellHeight * y);
+                int yMax = (int)Math.Floor(cellHeight * (y + 1));
+
+                for (int x = 0; x < gridSegmentWidth; x++)
+                {
+                    int xMin = (int)Math.Floor(cellWidth * x);
+                    int xMax = (int)Math.Floor(cellWidth * (x + 1));
+
+                    // Define the region of interest (ROI)
+                    SKRectI roi = new(xMin, yMin, xMax - 1, yMax - 1);
+
+                    // Get the character that best represents the region
+                    asciiArt[y, x] = GetSegmentCharacter(bitmap, roi, seg);
+                }
+            }
+
+            return asciiArt;
+        }
+    }
+}

--- a/Asciimage/Brushes/GridSegmentedFontBrush.cs
+++ b/Asciimage/Brushes/GridSegmentedFontBrush.cs
@@ -128,7 +128,7 @@ namespace Asciimage.Brushes
                 for (int x = xMin; x < xMax; x++)
                 {
                     SKColor color = bitmap.GetPixel(x, y);
-                    // 元画像がグレースケールという前提なので、HSVに変換してVを取得することで0-255での表現に変化できる
+                    // Assuming the original image is grayscale, convert to HSV and get V to represent it in the range of 0-255
                     color.ToHsv(out _, out _, out float v);
                     values.Add(v / 100);
                 }

--- a/Asciimage/Brushes/IFontBrush.cs
+++ b/Asciimage/Brushes/IFontBrush.cs
@@ -11,9 +11,6 @@ namespace Asciimage.Brushes
     public interface IFontBrush
     {
         public SKFontInfo FontInfo { get; init; }
-        //public SKSize CharacterRatio { get; init; }
-        //public Dictionary<SegmentCount, CharacterAreaMap> CharacterAreas { get; init; }
-        //public string GetLineString(SKBitmap bitmap, SKRect area, SegmentCount seg);
         public string[,] GetStringMap(SKBitmap bitmap, int stringWidth, int stringHeight, SegmentCount seg);
     }
 }

--- a/Asciimage/Brushes/IFontBrush.cs
+++ b/Asciimage/Brushes/IFontBrush.cs
@@ -1,4 +1,5 @@
-﻿using SkiaSharp;
+﻿using Asciimage.Core;
+using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,7 +11,9 @@ namespace Asciimage.Brushes
     public interface IFontBrush
     {
         public SKFontInfo FontInfo { get; init; }
-        public SKSize CharacterRatio { get; init; }
-        public Dictionary<SegmentCount, CharacterAreaMap> CharacterAreas { get; init; }
+        //public SKSize CharacterRatio { get; init; }
+        //public Dictionary<SegmentCount, CharacterAreaMap> CharacterAreas { get; init; }
+        //public string GetLineString(SKBitmap bitmap, SKRect area, SegmentCount seg);
+        public string[,] GetStringMap(SKBitmap bitmap, int stringWidth, int stringHeight, SegmentCount seg);
     }
 }

--- a/Asciimage/Core/Asciimage.cs
+++ b/Asciimage/Core/Asciimage.cs
@@ -37,57 +37,7 @@ namespace Asciimage.Core
                     throw new NotSupportedException("Color mode not supported.");
             }
 
-            // Calculate the number of segments
-            int horizontalSegmentCount, verticalSegmentCount;
-            if (config.Width == 0 && config.Height == 0 || config.Width < 0 || config.Height < 0)
-            {
-                throw new ArgumentException("Invalid config.");
-            }
-            else if (config.Height == 0)
-            {
-                double segmentWidth = (double)localImage.Width / config.Width;
-                double segmentHeight = segmentWidth * brush.CharacterRatio.Height / brush.CharacterRatio.Width;
-                verticalSegmentCount = (int)Math.Round(localImage.Height / segmentHeight);
-                horizontalSegmentCount = config.Width;
-            }
-            else if (config.Width == 0)
-            {
-                double segmentHeight = (double)localImage.Height / config.Height;
-                double segmentWidth = segmentHeight * brush.CharacterRatio.Width / brush.CharacterRatio.Height;
-                horizontalSegmentCount = (int)Math.Round(localImage.Width / segmentWidth);
-                verticalSegmentCount = config.Height;
-            }
-            else
-            {
-                horizontalSegmentCount = config.Width;
-                verticalSegmentCount = config.Height;
-            }
-
-            // Divide the image by config.Width and config.Height, and repeat the following process for each region
-            double cellWidth = (double)localImage.Width / horizontalSegmentCount;
-            double cellHeight = (double)localImage.Height / verticalSegmentCount;
-
-            string[,] asciiArt = new string[verticalSegmentCount, horizontalSegmentCount];
-
-            // Iterate over each region
-            for (int y = 0; y < verticalSegmentCount; y++)
-            {
-                for (int x = 0; x < horizontalSegmentCount; x++)
-                {
-                    int xMin = (int)Math.Floor(cellWidth * x);
-                    int xMax = (int)Math.Floor(cellWidth * (x + 1));
-                    int yMin = (int)Math.Floor(cellHeight * y);
-                    int yMax = (int)Math.Floor(cellHeight * (y + 1));
-
-                    // Define the region of interest (ROI)
-                    SKRectI roi = new(xMin, yMin, xMax - 1, yMax - 1);
-
-                    // Get the character that best represents the region
-                    asciiArt[y, x] = GetSimilarCharacter(localImage, roi, brush, seg);
-                }
-            }
-
-            return new AsciiMat(asciiArt);
+            return new AsciiMat(brush.GetStringMap(localImage, config.Width, config.Height, seg));
         }
 
         /// <summary>
@@ -139,90 +89,6 @@ namespace Asciimage.Core
             });
 
             image.Pixels = pixels;
-        }
-
-        /// <summary>
-        /// Gets the character that best represents the given region of the image.
-        /// </summary>
-        /// <param name="segmentBitmap">The image segment to be analyzed.</param>
-        /// <param name="rect">The region of interest (ROI) in the image segment.</param>
-        /// <param name="brush">The font brush used to determine character ratios and areas.</param>
-        /// <param name="seg">The segment count defining the granularity of the ASCII art.</param>
-        private static string GetSimilarCharacter(SKBitmap segmentBitmap, SKRectI rect, IFontBrush brush, SegmentCount seg)
-        {
-            var areaMap = brush.CharacterAreas[seg].RelativeAreaMap;
-
-            double[,] depthMap = new double[seg.Vertical, seg.Horizontal];
-
-            double w = (double)rect.Width / seg.Horizontal;
-            double h = (double)rect.Height / seg.Vertical;
-
-            int iMin, jMin = rect.Top;
-            int iMax, jMax;
-
-            for (int y = 0; y < seg.Vertical; y++)
-            {
-                jMax = (int)Math.Floor(h * (y + 1)) + rect.Top;
-                iMin = rect.Left;
-
-                for (int x = 0; x < seg.Horizontal; x++)
-                {
-                    double totalBrightness = 0;
-                    int pixelCount = 0;
-
-                    iMax = (int)Math.Floor(w * (x + 1)) + rect.Left;
-
-                    for (int j = jMin; j < jMax; j++)
-                    {
-                        for (int i = iMin; i < iMax; i++)
-                        {
-                            SKColor color = segmentBitmap.GetPixel(i, j);
-                            color.ToHsv(out _, out _, out float v);
-                            totalBrightness += v / 100;
-                            pixelCount++;
-                        }
-                    }
-
-                    depthMap[y, x] = totalBrightness / pixelCount;
-
-                    iMin = iMax;
-                }
-
-                jMin = jMax;
-            }
-
-            double minDiff = double.MaxValue;
-            string bestMatch = string.Empty;
-
-            foreach (var kvp in areaMap)
-            {
-                double[,] area = kvp.Value;
-                double diff = 0;
-
-                for (int y = 0; y < seg.Vertical; y++)
-                {
-                    for (int x = 0; x < seg.Horizontal; x++)
-                    {
-                        double d = area[y, x] - depthMap[y, x];
-                        diff += d == 0 ? 0 : d * d;
-                    }
-                }
-
-                diff /= seg.Vertical * seg.Horizontal;
-
-                if (diff < minDiff)
-                {
-                    minDiff = diff;
-                    bestMatch = kvp.Key;
-                }
-            }
-
-            if (bestMatch == string.Empty)
-            {
-                throw new InvalidOperationException("No match found.");
-            }
-
-            return bestMatch;
         }
     }
 }

--- a/Asciimage/Core/AsciimageConfig.cs
+++ b/Asciimage/Core/AsciimageConfig.cs
@@ -13,13 +13,13 @@ namespace Asciimage.Core
     {
         /// <summary>
         /// Width of the image.
-        /// If set to 0, it will be auto-adjusted to the original image width.
+        /// If set to -1, it will be auto-adjusted to the original image width.
         /// </summary>
         public int Width;
 
         /// <summary>
         /// Height of the image.
-        /// If set to 0, it will be auto-adjusted to the original image height.
+        /// If set to -1, it will be auto-adjusted to the original image height.
         /// </summary>
         public int Height;
 
@@ -35,9 +35,9 @@ namespace Asciimage.Core
         /// <param name="height">Height of the image.</param>
         /// <param name="colorMode">Color mode of the image.</param>
         /// <exception cref="ArgumentException">Thrown when both width and height are zero.</exception>
-        public AsciimageConfig(int width = 0, int height = 0, ColorMode colorMode = ColorMode.Binary)
+        public AsciimageConfig(int width = -1, int height = -1, ColorMode colorMode = ColorMode.Binary)
         {
-            if (width == 0 && height == 0)
+            if (width == -1 && height == -1 || width == 0 || height == 0)
             {
                 throw new ArgumentException("Either width or height must be specified.");
             }

--- a/AsciimageTester/Test1.cs
+++ b/AsciimageTester/Test1.cs
@@ -21,7 +21,7 @@ namespace AsciimageTester
             SegmentCount seg = new(14, 8);
             List<SegmentCount> segs = [SegmentCount.OneByOne, SegmentCount.TwoByTwo, SegmentCount.FourByTwo, SegmentCount.FourByFour, seg];
 
-            CusomFontBrush brush = new(font, ss, segs);
+            GridSegmentedFontBrush brush = new(font, ss, segs);
 
             int pointSize = 10;
             int LineCount = 10;

--- a/AsciimageTester/Test2.cs
+++ b/AsciimageTester/Test2.cs
@@ -21,8 +21,8 @@ public class Test2
         List<SegmentCount> segs = [SegmentCount.FourByTwo];
 
         Debug.WriteLine($"{DateTimeOffset.Now:HH:mm:ss.fff} Start Brush Creating");
-        
-        CusomFontBrush brush = new(font, ss, segs);
+
+        GridSegmentedFontBrush brush = new(font, ss, segs);
 
         Debug.WriteLine($"{DateTimeOffset.Now:HH:mm:ss.fff} Brush created");
 


### PR DESCRIPTION
This pull request includes significant refactoring and enhancements to the `Asciimage` library, particularly focusing on the `Brushes` and `Core` components. The changes introduce a new base class for font brushes, streamline the process of generating ASCII art, and improve code readability and maintainability.

Refactoring and Enhancements:

* [`Asciimage/Brushes/BaseGridSegmentFontBrush.cs`](diffhunk://#diff-19c092c3016dcc2c55701fb0a0160f7f80ac804480af76f533102236c2e6e974R1-R90): Introduced a new abstract base class `BaseGridSegmentedFontBrush` to handle common functionality for grid-segmented font brushes. This class includes methods for converting bitmap images to grid-segmented sizes and generating string maps from bitmaps.

* [`Asciimage/Brushes/GridSegmentedFontBrush.cs`](diffhunk://#diff-0df172248159bfbdfa9b9c44aac8cf570db5a64c8b58dc3e1bc6c73bf44550c7L1-R23): Renamed from `SegmentFontBrush.cs` and refactored to inherit from `BaseGridSegmentedFontBrush`. Removed redundant properties and methods, and implemented the `GetSegmentCharacter` method to determine the best character representation for a given bitmap segment. [[1]](diffhunk://#diff-0df172248159bfbdfa9b9c44aac8cf570db5a64c8b58dc3e1bc6c73bf44550c7L1-R23) [[2]](diffhunk://#diff-0df172248159bfbdfa9b9c44aac8cf570db5a64c8b58dc3e1bc6c73bf44550c7L48-L51) [[3]](diffhunk://#diff-0df172248159bfbdfa9b9c44aac8cf570db5a64c8b58dc3e1bc6c73bf44550c7L60-L61) [[4]](diffhunk://#diff-0df172248159bfbdfa9b9c44aac8cf570db5a64c8b58dc3e1bc6c73bf44550c7L72-L73) [[5]](diffhunk://#diff-0df172248159bfbdfa9b9c44aac8cf570db5a64c8b58dc3e1bc6c73bf44550c7L151-R215)

Interface and Configuration Updates:

* [`Asciimage/Brushes/IFontBrush.cs`](diffhunk://#diff-bf3527ce0bf59f6fa4bd4979d97b8a74517d9dd4e8e4bbb1e7d92ca224835a6cL1-R2): Updated the `IFontBrush` interface to include the `GetStringMap` method, which generates a string map from a bitmap. Removed properties that are now handled by the base class. [[1]](diffhunk://#diff-bf3527ce0bf59f6fa4bd4979d97b8a74517d9dd4e8e4bbb1e7d92ca224835a6cL1-R2) [[2]](diffhunk://#diff-bf3527ce0bf59f6fa4bd4979d97b8a74517d9dd4e8e4bbb1e7d92ca224835a6cL13-R14)

* [`Asciimage/Core/AsciimageConfig.cs`](diffhunk://#diff-bfe6dff81b313f146382c66b79f6cc5ab3cc6d946881d6ee8a804f7c1ae8eaf7L16-R22): Modified the `AsciimageConfig` structure to use `-1` instead of `0` for auto-adjusting image dimensions, improving clarity and consistency. [[1]](diffhunk://#diff-bfe6dff81b313f146382c66b79f6cc5ab3cc6d946881d6ee8a804f7c1ae8eaf7L16-R22) [[2]](diffhunk://#diff-bfe6dff81b313f146382c66b79f6cc5ab3cc6d946881d6ee8a804f7c1ae8eaf7L38-R40)

Code Simplification:

* [`Asciimage/Core/Asciimage.cs`](diffhunk://#diff-4fab0e4b1339f6c41311a2dffbc7edc38ac864116b9f1aa60cfcb15552e30682L40-R40): Simplified the `Generate` method by delegating the ASCII art generation to the `GetStringMap` method of the `IFontBrush` interface, removing redundant calculations and iterations. [[1]](diffhunk://#diff-4fab0e4b1339f6c41311a2dffbc7edc38ac864116b9f1aa60cfcb15552e30682L40-R40) [[2]](diffhunk://#diff-4fab0e4b1339f6c41311a2dffbc7edc38ac864116b9f1aa60cfcb15552e30682L143-L226)

Test Adjustments:

* `AsciimageTester/Test1.cs` and `AsciimageTester/Test2.cs`: Updated test cases to use the new `GridSegmentedFontBrush` class, reflecting the changes in the brush implementation. [[1]](diffhunk://#diff-2b5e7312ca4157a3901e529b3713ae16a4bf3eba606fde236460146fffe926d3L24-R24) [[2]](diffhunk://#diff-a09ef8c5d461239c407978db708ed0cf8b8c8cefbfc1025c383eea505591a86eL25-R25)