### PR TITLE
UIレイアウトの調整

### DIFF
--- a/AsciimageMaker/AsciimageMaker.csproj
+++ b/AsciimageMaker/AsciimageMaker.csproj
@@ -16,6 +16,9 @@
     <WindowsPackageType>None</WindowsPackageType>
     -->
   </PropertyGroup>
+  <ItemGroup>
+    <None Remove="Resources\AsciimageMakerLogo.png" />
+  </ItemGroup>
 
   <ItemGroup>
     <Content Include="Assets\SplashScreen.scale-200.png" />
@@ -24,6 +27,10 @@
     <Content Include="Assets\Square44x44Logo.scale-200.png" />
     <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Resources\AsciimageMakerLogo.png" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AsciimageMaker/MainWindow.xaml
+++ b/AsciimageMaker/MainWindow.xaml
@@ -9,97 +9,112 @@
     xmlns:ascc="using:Asciimage.Core"
     mc:Ignorable="d"
     Title="AsciimageMaker">
+    
+    <Window.SystemBackdrop>
+        <MicaBackdrop />
+    </Window.SystemBackdrop>
 
-    <Grid Padding="24" RowSpacing="24" ColumnSpacing="24">
-        <Grid.Resources>
-            <Style x:Key="NoClearButtonTextBoxStyle" TargetType="TextBox">
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="TextBox">
-                            <Grid>
-                                <VisualStateManager.VisualStateGroups>
-                                    <!-- 省略 -->
-                                </VisualStateManager.VisualStateGroups>
-                                <Border x:Name="Border" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}">
-                                    <ScrollViewer x:Name="ContentElement" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden" Margin="2" />
-                                </Border>
-                            </Grid>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-        </Grid.Resources>
+    <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="32"/>
             <RowDefinition/>
         </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition/>
-            <ColumnDefinition Width="Auto"/>
-            <ColumnDefinition/>
-        </Grid.ColumnDefinitions>
-        <Grid Grid.ColumnSpan="3" RowSpacing="12" ColumnSpacing="24">
+
+        <StackPanel x:Name="TitleBarStackPanel" Orientation="Horizontal" Padding="8" Spacing="12" Margin="0,0,138,0">
+            <Image Source="/Resources/AsciimageMakerLogo.png" Stretch="Uniform"/>
+            <TextBlock Text="Asciimage Maker" FontSize="12" VerticalAlignment="Center"/>
+        </StackPanel>
+
+        <Grid Grid.Row="1" Padding="24" RowSpacing="24" ColumnSpacing="24">
+            <Grid.Resources>
+                <Style x:Key="NoClearButtonTextBoxStyle" TargetType="TextBox">
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="TextBox">
+                                <Grid>
+                                    <VisualStateManager.VisualStateGroups>
+                                        <!-- 省略 -->
+                                    </VisualStateManager.VisualStateGroups>
+                                    <Border x:Name="Border" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}">
+                                        <ScrollViewer x:Name="ContentElement" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden" Margin="2" />
+                                    </Border>
+                                </Grid>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </Grid.Resources>
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition/>
-                <ColumnDefinition/>
-                <ColumnDefinition/>
-            </Grid.ColumnDefinitions>
-            <TextBox x:Name="UsingCharactersTextBox" Grid.ColumnSpan="3" Header="Using Characters (Only ASCII charcters)" Text=""/>
-            <ComboBox x:Name="ColorModeComboBox" Grid.Row="1" HorizontalAlignment="Stretch" Header="Color Mode">
-                <ComboBox.Resources>
-                    <ascc:ColorMode x:Key="ColorMode.Binary">Binary</ascc:ColorMode>
-                    <ascc:ColorMode x:Key="ColorMode.Grayscale">Grayscale</ascc:ColorMode>
-                    <ascc:ColorMode x:Key="ColorMode.Color">Color</ascc:ColorMode>
-                </ComboBox.Resources>
-                <ComboBoxItem Content="Binary" Tag="{StaticResource ColorMode.Binary}"/>
-                <ComboBoxItem Content="Grayscale" IsSelected="True" Tag="{StaticResource ColorMode.Grayscale}"/>
-                <ComboBoxItem IsEnabled="False" Content="Color" Tag="{StaticResource ColorMode.Color}"/>
-            </ComboBox>
-            <ComboBox x:Name="FilterComboBox" Grid.Row="1" Grid.Column="1" HorizontalAlignment="Stretch" Header="Filter">
-                <ComboBoxItem Content="None" Tag="none" IsSelected="True"/>
-                <ComboBoxItem Content="Sobel Filter" Tag="sobel"/>
-                <ComboBoxItem Content="Laplacian Filter" Tag="laplacian"/>
-            </ComboBox>
-            <ComboBox x:Name="SegmentCountComboBox" Grid.Row="2" HorizontalAlignment="Stretch" Header="Number of divisions in segment">
-                <ComboBoxItem Content="1 x 1" Tag="1;1" IsSelected="True"/>
-                <ComboBoxItem Content="2 x 1" Tag="2;1"/>
-                <ComboBoxItem Content="2 x 2" Tag="2;2"/>
-                <ComboBoxItem Content="4 x 2" Tag="4;2"/>
-                <ComboBoxItem Content="4 x 4" Tag="4;4"/>
-            </ComboBox>
-            <TextBox x:Name="FontFamilyNameTextBox" Grid.Row="1" Grid.Column="2" Header="Font Family Name" PlaceholderText="Cascadia Code" Text="Cascadia Code"/>
-            <Grid Grid.Row="2" Grid.ColumnSpan="3" ColumnSpacing="24">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition/>
-                    <ColumnDefinition/>
-                </Grid.ColumnDefinitions>
-            </Grid>
-            <Slider Grid.Row="2" Grid.Column="1" x:Name="WidthSlider" Header="Width (0 is Auto, default 20)" Value="20" Minimum="0" Maximum="100" ValueChanged="SizeSlider_ValueChanged"/>
-            <Slider Grid.Row="2" Grid.Column="2" x:Name="HeightSlider" Header="Height (0 is Auto, default 0)" Value="0" Minimum="0" Maximum="100" ValueChanged="SizeSlider_ValueChanged"/>
-        </Grid>
-        <Grid Grid.Row="1" RowSpacing="8">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition/>
             </Grid.RowDefinitions>
-            <StackPanel HorizontalAlignment="Center" Spacing="24">
-                <Button Content="Open File" Click="InputImageSelectButton_Click"/>
-            </StackPanel>
-            <TextBlock Grid.Row="1" x:Name="OpenedFileName" HorizontalAlignment="Center" TextWrapping="Wrap"/>
-            <Border Grid.Row="2" HorizontalAlignment="Center" VerticalAlignment="Center" BorderThickness="1" BorderBrush="Gray">
-                <Viewbox>
-                    <Image x:Name="InputImage"/>
-                </Viewbox>
-            </Border>
-        </Grid>
-        <Button x:Name="GenerateButton" Grid.Row="1" Grid.Column="1" Click="GenerateButton_Click" Content="Generate"/>
-        <!--
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition/>
+            </Grid.ColumnDefinitions>
+            <Grid Grid.ColumnSpan="3" RowSpacing="12" ColumnSpacing="24">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                </Grid.ColumnDefinitions>
+                <TextBox x:Name="UsingCharactersTextBox" Grid.ColumnSpan="3" Header="Using Characters (Only ASCII charcters)" Text=""/>
+                <ComboBox x:Name="ColorModeComboBox" Grid.Row="1" HorizontalAlignment="Stretch" Header="Color Mode">
+                    <ComboBox.Resources>
+                        <ascc:ColorMode x:Key="ColorMode.Binary">Binary</ascc:ColorMode>
+                        <ascc:ColorMode x:Key="ColorMode.Grayscale">Grayscale</ascc:ColorMode>
+                        <ascc:ColorMode x:Key="ColorMode.Color">Color</ascc:ColorMode>
+                    </ComboBox.Resources>
+                    <ComboBoxItem Content="Binary" Tag="{StaticResource ColorMode.Binary}"/>
+                    <ComboBoxItem Content="Grayscale" IsSelected="True" Tag="{StaticResource ColorMode.Grayscale}"/>
+                    <ComboBoxItem IsEnabled="False" Content="Color" Tag="{StaticResource ColorMode.Color}"/>
+                </ComboBox>
+                <ComboBox x:Name="FilterComboBox" Grid.Row="1" Grid.Column="1" HorizontalAlignment="Stretch" Header="Filter">
+                    <ComboBoxItem Content="None" Tag="none" IsSelected="True"/>
+                    <ComboBoxItem Content="Sobel Filter" Tag="sobel"/>
+                    <ComboBoxItem Content="Laplacian Filter" Tag="laplacian"/>
+                </ComboBox>
+                <ComboBox x:Name="SegmentCountComboBox" Grid.Row="2" HorizontalAlignment="Stretch" Header="Number of divisions in segment">
+                    <ComboBoxItem Content="1 x 1" Tag="1;1" IsSelected="True"/>
+                    <ComboBoxItem Content="2 x 1" Tag="2;1"/>
+                    <ComboBoxItem Content="2 x 2" Tag="2;2"/>
+                    <ComboBoxItem Content="4 x 2" Tag="4;2"/>
+                    <ComboBoxItem Content="4 x 4" Tag="4;4"/>
+                </ComboBox>
+                <TextBox x:Name="FontFamilyNameTextBox" Grid.Row="1" Grid.Column="2" Header="Font Family Name" PlaceholderText="Cascadia Code" Text="Cascadia Code"/>
+                <Grid Grid.Row="2" Grid.ColumnSpan="3" ColumnSpacing="24">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition/>
+                        <ColumnDefinition/>
+                    </Grid.ColumnDefinitions>
+                </Grid>
+                <Slider Grid.Row="2" Grid.Column="1" x:Name="WidthSlider" Header="Width (0 is Auto, default 20)" Value="20" Minimum="0" Maximum="100" ValueChanged="SizeSlider_ValueChanged"/>
+                <Slider Grid.Row="2" Grid.Column="2" x:Name="HeightSlider" Header="Height (0 is Auto, default 0)" Value="0" Minimum="0" Maximum="100" ValueChanged="SizeSlider_ValueChanged"/>
+            </Grid>
+            <Grid Grid.Row="1" RowSpacing="8">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+                <StackPanel HorizontalAlignment="Center" Spacing="24">
+                    <Button Content="Open File" Click="InputImageSelectButton_Click"/>
+                </StackPanel>
+                <TextBlock Grid.Row="1" x:Name="OpenedFileName" HorizontalAlignment="Center" TextWrapping="Wrap"/>
+                <Border Grid.Row="2" HorizontalAlignment="Center" VerticalAlignment="Center" BorderThickness="1" BorderBrush="Gray">
+                    <Viewbox>
+                        <Image x:Name="InputImage"/>
+                    </Viewbox>
+                </Border>
+            </Grid>
+            <Button x:Name="GenerateButton" Grid.Row="1" Grid.Column="1" Click="GenerateButton_Click" Content="Generate"/>
+            <!--
         <TeachingTip x:Name="GenerateTeachingTip" IsOpen="True"
             Target="{x:Bind GenerateButton}"
             Title="Brush Re-Generation"
@@ -109,27 +124,28 @@
             </TeachingTip.IconSource>
         </TeachingTip>
         -->
-        <Grid Grid.Row="1" Grid.Column="2" RowSpacing="8">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition/>
-            </Grid.RowDefinitions>
-            <StackPanel Orientation="Horizontal" Spacing="24" HorizontalAlignment="Center">
-                <Button x:Name="CopyButton" Click="CopyResultButton_Click">
-                    <StackPanel Orientation="Horizontal" Spacing="8">
-                        <SymbolIcon Symbol="Copy"/>
-                        <TextBlock Text="Copy"/>
-                    </StackPanel>
-                </Button>
-            </StackPanel>
-            <!-- unused -->
-            <TextBlock Grid.Row="1" x:Name="OutputInfoTextBlock" HorizontalAlignment="Center"/>
-            <Border Grid.Row="2" HorizontalAlignment="Center" VerticalAlignment="Center" BorderThickness="1" BorderBrush="Gray" Background="Black">
-                <Viewbox>
-                    <TextBlock x:Name="GeneratedRichTextBox" IsTextSelectionEnabled="True" HorizontalAlignment="Center" VerticalAlignment="Center" TextAlignment="Left" FontFamily="Cascadia Code"/>
-                </Viewbox>
-            </Border>
+            <Grid Grid.Row="1" Grid.Column="2" RowSpacing="8">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+                <StackPanel Orientation="Horizontal" Spacing="24" HorizontalAlignment="Center">
+                    <Button x:Name="CopyButton" Click="CopyResultButton_Click">
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <SymbolIcon Symbol="Copy"/>
+                            <TextBlock Text="Copy"/>
+                        </StackPanel>
+                    </Button>
+                </StackPanel>
+                <!-- unused -->
+                <TextBlock Grid.Row="1" x:Name="OutputInfoTextBlock" HorizontalAlignment="Center"/>
+                <Border Grid.Row="2" HorizontalAlignment="Center" VerticalAlignment="Center" BorderThickness="1" BorderBrush="Gray" Background="Black">
+                    <Viewbox>
+                        <TextBlock x:Name="GeneratedRichTextBox" IsTextSelectionEnabled="True" HorizontalAlignment="Center" VerticalAlignment="Center" TextAlignment="Left" FontFamily="Cascadia Code"/>
+                    </Viewbox>
+                </Border>
+            </Grid>
         </Grid>
     </Grid>
 </Window>

--- a/AsciimageMaker/MainWindow.xaml.cs
+++ b/AsciimageMaker/MainWindow.xaml.cs
@@ -53,6 +53,8 @@ namespace AsciimageMaker
         public MainWindow()
         {
             this.InitializeComponent();
+            ExtendsContentIntoTitleBar = true;
+            SetTitleBar(TitleBarStackPanel);
             
             UsingCharactersTextBox.Text = CachedUsingCharacters;
             UsingCharactersTextBox.PlaceholderText = CachedUsingCharacters;


### PR DESCRIPTION
[update #23] UIレイアウトの調整とリソース設定の更新

AsciimageMaker.csproj:
- `Resources\AsciimageMakerLogo.png`を削除し、再度追加するための設定を追加。
- `Resources\AsciimageMakerLogo.png`を`Content`として含める設定を追加。

MainWindow.xaml:
- `Window.SystemBackdrop`に`MicaBackdrop`を追加し、ウィンドウの背景をMicaに設定。
- グリッドのレイアウトを変更し、`TitleBarStackPanel`を追加してタイトルバーにロゴとテキストを表示。

MainWindow.xaml.cs:
- コンストラクタに`ExtendsContentIntoTitleBar`と`SetTitleBar(TitleBarStackPanel)`を追加し、カスタムタイトルバーを設定。